### PR TITLE
Use content_type instead of deprecated mimetype

### DIFF
--- a/excel_response2.py
+++ b/excel_response2.py
@@ -82,7 +82,7 @@ class ExcelResponse(HttpResponse):
                         cell_style = styles['default']
                     sheet.write(rowx, colx, value, style=cell_style)
             book.save(output)
-            mimetype = 'application/vnd.ms-excel'
+            content_type = 'application/vnd.ms-excel'
             file_ext = 'xls'
         else:
             for row in data:
@@ -94,10 +94,10 @@ class ExcelResponse(HttpResponse):
                     out_row.append(value.replace('"', '""'))
                 output.write('"%s"\n' %
                              '","'.join(out_row))
-            mimetype = 'text/csv'
+            content_type = 'text/csv'
             file_ext = 'csv'
         output.seek(0)
         super(ExcelResponse, self).__init__(content=output.getvalue(),
-                                            mimetype=mimetype)
+                                            content_type=mimetype)
         self['Content-Disposition'] = 'attachment;filename="%s.%s"' % \
             (output_name.replace('"', '\"'), file_ext)


### PR DESCRIPTION
Fixes compatibility with Django 1.8
